### PR TITLE
feat: add development certificate generation code

### DIFF
--- a/scripts/generateExampleCertificates.ts
+++ b/scripts/generateExampleCertificates.ts
@@ -28,7 +28,7 @@ export async function run(): Promise<void> {
   const expoGo = await generateExpoGoIntermediateCertificate(root);
   await exportCertificateAndKeysAsync(expoGo, 'expo-go');
 
-  const developmentCSR = await generateDevelopmentCSR(testAppId, testScopeKey);
+  const developmentCSR = await generateDevelopmentCSR(testAppId);
 
   const testDevelopmentCert = await generateTestDevelopmentCertificate(developmentCSR, expoGo);
   await exportCertificateAndKeysAsync(testDevelopmentCert, 'development');
@@ -202,9 +202,9 @@ async function generateExpoGoIntermediateCertificate(
   };
 }
 
-async function generateDevelopmentCSR(projectId: string, scopeKey: string): Promise<KeysAndCSR> {
+async function generateDevelopmentCSR(projectId: string): Promise<KeysAndCSR> {
   const keyPair = generateKeyPair();
-  const csr = generateCSR(keyPair);
+  const csr = generateCSR(keyPair, `Expo Go Development Certificate ${projectId}`);
   return {
     ...keyPair,
     csr,

--- a/src/__tests__/main-test.ts
+++ b/src/__tests__/main-test.ts
@@ -269,7 +269,7 @@ describe('CSR generation and certificate generation from CA + CSR', () => {
     const issuerCertificate = convertCertificatePEMToCertificate(issuerCertificatePEM);
 
     const keyPair = generateKeyPair();
-    const csr1 = generateCSR(keyPair);
+    const csr1 = generateCSR(keyPair, 'Test common name');
 
     const csrPEM = convertCSRToCSRPEM(csr1);
     const csr = convertCSRPEMToCSR(csrPEM);
@@ -284,6 +284,8 @@ describe('CSR generation and certificate generation from CA + CSR', () => {
 
     // check signed by issuer
     expect(issuerCertificate.verify(certificate)).toBe(true);
+    // check subject attributes are transferred
+    expect(certificate.subject.getField('CN').value).toEqual('Test common name');
     // check extensions
     expect(certificate.getExtension('keyUsage')).toMatchObject({
       critical: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -272,11 +272,19 @@ export function signStringRSASHA256AndVerify(
 /**
  * Generate a self-signed CSR for a given key pair. Most commonly used with {@link generateDevelopmentCertificateFromCSR}.
  * @param keyPair RSA key pair
+ * @param commonName commonName attribute of the subject of the resulting certificate (human readable name of the certificate)
  * @returns CSR
  */
-export function generateCSR(keyPair: PKI.rsa.KeyPair): PKI.CertificateRequest {
+export function generateCSR(keyPair: PKI.rsa.KeyPair, commonName: string): PKI.CertificateRequest {
   const csr = PKI.createCertificationRequest();
   csr.publicKey = keyPair.publicKey;
+  const attrs = [
+    {
+      name: 'commonName',
+      value: commonName,
+    },
+  ];
+  csr.setSubject(attrs);
   csr.sign(keyPair.privateKey, md.sha256.create());
   return csr;
 }
@@ -286,7 +294,7 @@ export function generateCSR(keyPair: PKI.rsa.KeyPair): PKI.CertificateRequest {
  * appId and scopeKey (fields verified by the client during certificate validation).
  *
  * Note that this function assumes the issuer is trusted, and that the user that created the CSR and issued
- * the request has permission to sign manifests for the appId and scopeKey. This constraint shold be
+ * the request has permission to sign manifests for the appId and scopeKey. This constraint must be
  * verified on the server before calling this method.
  *
  * @param issuerPrivateKey private key to sign the resulting certificate with
@@ -294,7 +302,6 @@ export function generateCSR(keyPair: PKI.rsa.KeyPair): PKI.CertificateRequest {
  * @param csr certificate signing request containing the user's public key
  * @param appId app ID (UUID) of the app that the resulting certificate will sign the development manifest for
  * @param scopeKey scope key of the app that the resuting certificate will sign the development manifest for
- * @param commonName commonName attribute of the subject of the resulting certificate (human readable name of the certificate)
  * @returns certificate to use to sign development manifests
  */
 export function generateDevelopmentCertificateFromCSR(

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,10 @@ import { md, pki as PKI, random, util } from 'node-forge';
 
 import { toPositiveHex } from './utils';
 
+// generated with oidgen script. in the microsoft OID space. could apply for Expo space but would take time: https://pen.iana.org/pen/PenApplication.page
+export const expoProjectInformationOID =
+  '1.2.840.113556.1.8000.2554.43437.254.128.102.157.7894389.20439.2.1';
+
 /**
  * Generate a public and private RSA key pair.
  * @returns RSA key pair
@@ -78,7 +82,25 @@ export function convertPrivateKeyPEMToPrivateKey(privateKeyPEM: string): PKI.rsa
  * @returns  X.509 Certificate
  */
 export function convertCertificatePEMToCertificate(certificatePEM: string): PKI.Certificate {
-  return PKI.certificateFromPem(certificatePEM);
+  return PKI.certificateFromPem(certificatePEM, true);
+}
+
+/**
+ * Convert a CSR to PEM-formatted X.509 CSR
+ * @param csr CSR
+ * @returns X.509 CSR
+ */
+export function convertCSRToCSRPEM(csr: PKI.CertificateRequest): string {
+  return PKI.certificationRequestToPem(csr);
+}
+
+/**
+ * Convert a PEM-formatted X.509 CSR to a CSR
+ * @param CSRPEM PEM-formatted X.509 CSR
+ * @returns CSR
+ */
+export function convertCSRPEMToCSR(CSRPEM: string): PKI.CertificateRequest {
+  return PKI.certificationRequestFromPem(CSRPEM, true) as PKI.CertificateRequest;
 }
 
 type GenerateParameters = {
@@ -245,4 +267,86 @@ export function signStringRSASHA256AndVerify(
   }
 
   return util.encode64(digestSignature);
+}
+
+/**
+ * Generate a self-signed CSR for a given key pair. Most commonly used with {@link generateDevelopmentCertificateFromCSR}.
+ * @param keyPair RSA key pair
+ * @returns CSR
+ */
+export function generateCSR(keyPair: PKI.rsa.KeyPair): PKI.CertificateRequest {
+  const csr = PKI.createCertificationRequest();
+  csr.publicKey = keyPair.publicKey;
+  csr.sign(keyPair.privateKey, md.sha256.create());
+  return csr;
+}
+
+/**
+ * For use by a server to generate a development certificate (good for 30 days) for a particular
+ * appId and scopeKey (fields verified by the client during certificate validation).
+ *
+ * Note that this function assumes the issuer is trusted, and that the user that created the CSR and issued
+ * the request has permission to sign manifests for the appId and scopeKey. This constraint shold be
+ * verified on the server before calling this method.
+ *
+ * @param issuerPrivateKey private key to sign the resulting certificate with
+ * @param issuerCertificate parent certificate (should be a CA) of the resulting certificate
+ * @param csr certificate signing request containing the user's public key
+ * @param appId app ID (UUID) of the app that the resulting certificate will sign the development manifest for
+ * @param scopeKey scope key of the app that the resuting certificate will sign the development manifest for
+ * @param commonName commonName attribute of the subject of the resulting certificate (human readable name of the certificate)
+ * @returns certificate to use to sign development manifests
+ */
+export function generateDevelopmentCertificateFromCSR(
+  issuerPrivateKey: PKI.rsa.PrivateKey,
+  issuerCertificate: PKI.Certificate,
+  csr: PKI.CertificateRequest,
+  appId: string,
+  scopeKey: string
+): PKI.Certificate {
+  assert(csr.verify(csr), 'CSR not self-signed');
+
+  const certificate = PKI.createCertificate();
+  certificate.publicKey = csr.publicKey;
+  certificate.serialNumber = toPositiveHex(util.bytesToHex(random.getBytesSync(9)));
+
+  // set certificate subject attrs from CSR
+  certificate.setSubject(csr.subject.attributes);
+
+  // 30 day validity
+  certificate.validity.notBefore = new Date();
+  certificate.validity.notAfter = new Date();
+  certificate.validity.notAfter.setDate(certificate.validity.notBefore.getDate() + 30);
+
+  certificate.setIssuer(issuerCertificate.subject.attributes);
+
+  certificate.setExtensions([
+    {
+      name: 'keyUsage',
+      critical: true,
+      keyCertSign: false,
+      digitalSignature: true,
+      nonRepudiation: false,
+      keyEncipherment: false,
+      dataEncipherment: false,
+    },
+    {
+      name: 'extKeyUsage',
+      critical: true,
+      serverAuth: false,
+      clientAuth: false,
+      codeSigning: true,
+      emailProtection: false,
+      timeStamping: false,
+    },
+    {
+      name: 'expoProjectInformation',
+      id: expoProjectInformationOID,
+      // critical: true, // can't be critical since openssl verify doesn't know about this extension
+      value: `${appId},${scopeKey}`,
+    },
+  ]);
+
+  certificate.sign(issuerPrivateKey, md.sha256.create());
+  return certificate;
 }


### PR DESCRIPTION
# Why

This adds code that will be used by www to generate and serve development certificates. These will be children of the Expo Go certificate (which is a child of the Expo Root certificate), and will have expiries of 30 days. They will also only be able to sign manifests for a single app (by using the `expoProjectInformation` extension)

# How

Add functions, add tests.

# Test Plan

Run tests. `yarn link` this into the universe PR and ensure everything works.
