### PR TITLE
chore: test for 2048 bit length in generated key

### DIFF
--- a/src/__tests__/main-test.ts
+++ b/src/__tests__/main-test.ts
@@ -24,6 +24,7 @@ describe(generateKeyPair, () => {
     const keyPair = generateKeyPair();
     expect(keyPair.privateKey).toBeTruthy();
     expect(keyPair.publicKey).toBeTruthy();
+    expect(keyPair.publicKey.n.bitLength()).toEqual(2048);
 
     const digest = md.sha256.create().update('hello');
     expect(


### PR DESCRIPTION
# Why

Just a sanity check that the default arg remains 2048 bits for this function.

Closes ENG-4297.

# How

Add test.

# Test Plan

Run test.
