### PR TITLE
fix: add code to be robust against server clock skew

### DIFF
--- a/src/__tests__/main-test.ts
+++ b/src/__tests__/main-test.ts
@@ -313,5 +313,10 @@ describe('CSR generation and certificate generation from CA + CSR', () => {
       id: expoProjectInformationOID,
       value: 'testApp,testScopeKey',
     });
+    expect(certificate.validity.notBefore.getTime()).toBeLessThanOrEqual(Date.now());
+
+    const expectedNotAfter = certificate.validity.notBefore;
+    expectedNotAfter.setDate(expectedNotAfter.getDate() + 30);
+    expect(certificate.validity.notAfter.getTime()).toEqual(expectedNotAfter.getTime());
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -325,9 +325,9 @@ export function generateDevelopmentCertificateFromCSR(
   // set certificate subject attrs from CSR
   certificate.setSubject(csr.subject.attributes);
 
-  // 30 day validity into the future, 5 days in the past just in case of clock skew at callsite
+  // 30 day validity into the future, 1 day in the past just in case of clock skew at callsite
   certificate.validity.notBefore = new Date();
-  certificate.validity.notBefore.setDate(certificate.validity.notBefore.getDate() - 5);
+  certificate.validity.notBefore.setDate(certificate.validity.notBefore.getDate() - 1);
   certificate.validity.notAfter = new Date();
   certificate.validity.notAfter.setDate(certificate.validity.notBefore.getDate() + 30);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -325,8 +325,9 @@ export function generateDevelopmentCertificateFromCSR(
   // set certificate subject attrs from CSR
   certificate.setSubject(csr.subject.attributes);
 
-  // 30 day validity
+  // 30 day validity into the future, 5 days in the past just in case of clock skew at callsite
   certificate.validity.notBefore = new Date();
+  certificate.validity.notBefore.setDate(certificate.validity.notBefore.getDate() - 5);
   certificate.validity.notAfter = new Date();
   certificate.validity.notAfter.setDate(certificate.validity.notBefore.getDate() + 30);
 


### PR DESCRIPTION
# Why

We're seeing some issues on our end where our servers might be experiencing clock skew (into the future) and therefore are generating development certs that are not valid yet.

https://github.com/expo/expo/issues/19346

# How

Make the development certs valid 5 days in the past to 30 days in the future.

# Test Plan

Run test.
