### PR TITLE
fix: allow encoding to be specified for signStringRSASHA256AndVerify

### DIFF
--- a/src/__tests__/main-test.ts
+++ b/src/__tests__/main-test.ts
@@ -255,7 +255,7 @@ describe(signStringRSASHA256AndVerify, () => {
     ]);
     const privateKey = convertPrivateKeyPEMToPrivateKey(privateKeyPEM);
     const certificate = convertCertificatePEMToCertificate(certificatePEM);
-    const signature = signStringRSASHA256AndVerify(privateKey, certificate, 'hello');
+    const signature = signStringRSASHA256AndVerify(privateKey, certificate, 'hello', 'utf8');
     expect(signature).toMatchSnapshot();
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { md, pki as PKI, random, util } from 'node-forge';
+import { Encoding, md, pki as PKI, random, util } from 'node-forge';
 
 import { toPositiveHex } from './utils';
 
@@ -258,9 +258,10 @@ export function validateSelfSignedCertificate(
 export function signStringRSASHA256AndVerify(
   privateKey: PKI.rsa.PrivateKey,
   certificate: PKI.Certificate,
-  stringToSign: string
+  stringToSign: string,
+  encoding: Encoding
 ): string {
-  const digest = md.sha256.create().update(stringToSign);
+  const digest = md.sha256.create().update(stringToSign, encoding);
   const digestSignature = privateKey.sign(digest);
   const isValidSignature = (certificate.publicKey as PKI.rsa.PublicKey).verify(
     digest.digest().getBytes(),


### PR DESCRIPTION
# Why

First part of the fix to https://github.com/expo/expo/issues/19431.

We need to specify that the string is utf-8 (what the development server serves) when doing the signing.

# How

Add `encoding` parameter. While we could default this to utf-8, there probably exists a case in this world where someone using the library encodes their responses differently than we do and wants to use a different encoding. That being said, node-forge only supports `utf-8` and `raw` (and it's unclear/undocumented what `raw` does, though it is the default value when the param is omitted).

# Test Plan

Run test.
